### PR TITLE
fix: how to get pid and readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Standard logging library for golang projects
 
-## Instalation
+## Installation
 
 In order to use the library, you must create the configuration, a new logger instance and the methods you want to use.
 
@@ -32,7 +32,7 @@ func init() {
     ConsoleLevel: "info",
   }
 
-  Log = logging.NewLogger(configuration)
+  log = logging.NewLogger(configuration)
 }
 
 func Info(description string, message string, payload map[string]string) {

--- a/utils.go
+++ b/utils.go
@@ -43,7 +43,7 @@ func getLogLevel(level string) zapcore.Level {
 
 func createLogger(config Configuration, logger *zap.Logger) *zap.Logger {
 	host, _ := os.Hostname()
-	pid := os.Getegid()
+	pid := os.Getpid()
 
 	logger = logger.With(
 		zap.Int("pid", pid),


### PR DESCRIPTION
Se corrige la forma en como se obtiene el identificador del proceso y un error tipográfico en el readme